### PR TITLE
Centralize dataset configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ An AI-powered data analysis agent that processes e-commerce data from Google Big
    
    # BigQuery Configuration (optional)
    BQ_DATASET_ID=bigquery-public-data.thelook_ecommerce
+
+   # Deployment Environment (optional: development|production)
+   APP_ENV=development
    
    # LangSmith Tracing (optional - for debugging)
    LANGSMITH_API_KEY=your_langsmith_api_key_here

--- a/bq_client.py
+++ b/bq_client.py
@@ -5,6 +5,7 @@ from google.cloud import bigquery
 
 from logging_config import get_logger
 from tracing.langsmith_setup import tracer
+from config import config
 
 logger = get_logger(__name__)
 
@@ -12,17 +13,17 @@ logger = get_logger(__name__)
 class BigQueryRunner:
     """A lean BigQuery client for executing SQL queries and returning DataFrame results."""
     
-    def __init__(self, project_id: Optional[str] = None, dataset_id: Optional[str] = "bigquery-public-data.thelook_ecommerce") -> None:
+    def __init__(self, project_id: Optional[str] = None, dataset_id: Optional[str] = None) -> None:
         """Initialize BigQuery client.
         
         Args:
             project_id: Google Cloud project ID. If None, uses default credentials.
-            dataset_id: BigQuery dataset ID. If None, uses default dataset.
+            dataset_id: BigQuery dataset ID. If None, uses value from global config.
         """
         logger.info("Initializing BigQuery client")
         try:
             self.client = bigquery.Client(project=project_id)
-            self.dataset_id = dataset_id
+            self.dataset_id = dataset_id or config.api_configurations.dataset_id
             logger.info(f"BigQuery client initialized for dataset: {self.dataset_id}")
         except Exception as e:
             logger.error(f"Failed to initialize BigQuery client: {str(e)}")

--- a/utils/sql_utils.py
+++ b/utils/sql_utils.py
@@ -1,5 +1,10 @@
 """Shared SQL utility functions."""
 
+from config import config
+
+DATASET_ID = config.api_configurations.dataset_id
+MAX_RESULTS = config.api_configurations.max_query_results
+
 
 def clean_sql_query(sql_query: str, add_dataset_prefix: bool = True, add_limit: bool = True) -> str:
     """
@@ -28,15 +33,15 @@ def clean_sql_query(sql_query: str, add_dataset_prefix: bool = True, add_limit: 
         sql_query = sql_query[:-1]
     
     # Add dataset prefix if missing and requested
-    if add_dataset_prefix and "bigquery-public-data.thelook_ecommerce" not in sql_query:
+    if add_dataset_prefix and DATASET_ID not in sql_query:
         for table in ["orders", "order_items", "products", "users"]:
-            sql_query = sql_query.replace(f" {table} ", f" `bigquery-public-data.thelook_ecommerce.{table}` ")
-            sql_query = sql_query.replace(f"FROM {table}", f"FROM `bigquery-public-data.thelook_ecommerce.{table}`")
-            sql_query = sql_query.replace(f"JOIN {table}", f"JOIN `bigquery-public-data.thelook_ecommerce.{table}`")
+            sql_query = sql_query.replace(f" {table} ", f" `{DATASET_ID}.{table}` ")
+            sql_query = sql_query.replace(f"FROM {table}", f"FROM `{DATASET_ID}.{table}`")
+            sql_query = sql_query.replace(f"JOIN {table}", f"JOIN `{DATASET_ID}.{table}`")
     
     # Ensure LIMIT clause for performance if requested
     if add_limit and "LIMIT" not in sql_query.upper():
-        sql_query += " LIMIT 10000"
+        sql_query += f" LIMIT {MAX_RESULTS}"
     
     return sql_query.strip()
 


### PR DESCRIPTION
## Summary
- centralize BigQuery dataset ID and max result limit via global config
- add environment-based configuration loader for dev/prod setups
- reference config-driven dataset ID in SQL generation utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c180a7cd448332a73d245e61edf9af