### PR TITLE
chore: tidy up unused imports

### DIFF
--- a/cli/interface.py
+++ b/cli/interface.py
@@ -6,17 +6,13 @@ from datetime import datetime
 import click
 from rich.console import Console
 from rich.table import Table
-from rich.panel import Panel
-from rich.markdown import Markdown
-from rich.text import Text
-from rich.prompt import Prompt, Confirm
+from rich.prompt import Confirm
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from prompt_toolkit import prompt
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.completion import WordCompleter
 
 from workflow.graph import session_manager
-from config import config
 from logging_config import get_logger
 from utils.sql_utils import format_error_message
 
@@ -48,7 +44,7 @@ class DataAnalysisCLI:
         try:
             # Start new session
             self.session_id = session_manager.start_session()
-            self.console.print(f"✓ Ready to analyze your data!")
+            self.console.print("✓ Ready to analyze your data!")
             
             # Show help message
             self._show_help()

--- a/execution/sandbox.py
+++ b/execution/sandbox.py
@@ -1,15 +1,12 @@
 """Secure code execution environment with sandboxing."""
-import sys
 import io
 import time
 import traceback
 import resource
 import signal
 import multiprocessing as mp
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict
 import logging
-import pandas as pd
-import numpy as np
 from contextlib import redirect_stdout, redirect_stderr
 
 from config import config
@@ -185,7 +182,6 @@ class SecureExecutor:
             from scipy.stats import pearsonr, spearmanr, normaltest, shapiro
             import statsmodels.api as sm
             from prophet import Prophet
-            import datetime
             from datetime import datetime, timedelta
             import math
             import statistics
@@ -304,7 +300,7 @@ class ProcessSafeExecutor:
             result = result_queue.get_nowait()
             result.execution_time = time.time() - start_time
             return result
-        except:
+        except Exception:
             return ExecutionResults(
                 status=ExecutionStatus.FAILED,
                 execution_time=time.time() - start_time,

--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 """Main entry point for the LangGraph Data Analysis Agent."""
-import os
 import sys
 import logging
 import warnings
@@ -13,8 +12,8 @@ warnings.filterwarnings("ignore", category=UserWarning, module="google.cloud.big
 project_root = Path(__file__).parent
 sys.path.insert(0, str(project_root))
 
-from cli.interface import main as cli_main
-from config import config
+from cli.interface import main as cli_main  # noqa: E402
+from config import config  # noqa: E402
 
 
 def setup_logging(debug: bool = False) -> None:

--- a/workflow/graph.py
+++ b/workflow/graph.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import uuid
 
 from langgraph.graph import StateGraph, END
-from langchain_core.runnables import RunnableLambda
 
 from workflow.state import AnalysisState, create_initial_state, ConversationMessage
 from workflow.nodes import workflow_nodes

--- a/workflow/nodes.py
+++ b/workflow/nodes.py
@@ -1,11 +1,10 @@
 """LangGraph workflow nodes for the data analysis agent."""
-import json
 from datetime import datetime
 from typing import Dict, Any
 
 import pandas as pd
 
-from workflow.state import AnalysisState, ProcessType, ConversationMessage, AnalysisLineage, GeneratedCode
+from workflow.state import AnalysisState, ProcessType, ConversationMessage, GeneratedCode
 from agents.process_classifier import process_classifier, ProcessTypeResult
 from agents.schema_agent import schema_agent
 from agents.sql_agent import sql_agent
@@ -15,7 +14,6 @@ from execution.sandbox import secure_executor
 from logging_config import get_logger
 from services.llm_service import GeminiService
 from tracing.langsmith_setup import tracer, trace_agent_operation
-from utils.sql_utils import clean_sql_query, format_error_message
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- drop unused imports across CLI, sandbox, and workflow modules
- clean up main startup script and fix linter warnings

## Testing
- `ruff check cli/interface.py main.py execution/sandbox.py workflow/nodes.py workflow/graph.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1e9ff52c08332aeb4e3125641c2c9