### PR TITLE
Use default list for suggested tables

### DIFF
--- a/agents/process_classifier.py
+++ b/agents/process_classifier.py
@@ -1,6 +1,6 @@
 """AI-driven process type classification agent."""
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, Any, List
 
 from workflow.state import ProcessType
@@ -19,11 +19,7 @@ class ProcessTypeResult:
     reasoning: str
     requires_aggregation: bool = False
     complexity_level: str = "medium"  # low, medium, high
-    suggested_tables: List[str] = None
-    
-    def __post_init__(self):
-        if self.suggested_tables is None:
-            self.suggested_tables = []
+    suggested_tables: List[str] = field(default_factory=list)
 
 
 class ProcessTypeClassifier:


### PR DESCRIPTION
## Summary
- Use dataclasses `field` to give `suggested_tables` a default empty list
- Remove the `__post_init__` in favor of `field(default_factory=list)`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1f905799c83328fe5b792bd70b2ed