### PR TITLE
Use central logger in main and sandbox

### DIFF
--- a/execution/sandbox.py
+++ b/execution/sandbox.py
@@ -7,15 +7,15 @@ import resource
 import signal
 import multiprocessing as mp
 from typing import Any, Dict, Optional, Tuple
-import logging
 import pandas as pd
 import numpy as np
 from contextlib import redirect_stdout, redirect_stderr
 
 from config import config
 from workflow.state import ExecutionStatus, ExecutionResults
+from logging_config import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class TimeoutException(Exception):

--- a/main.py
+++ b/main.py
@@ -1,7 +1,5 @@
 """Main entry point for the LangGraph Data Analysis Agent."""
-import os
 import sys
-import logging
 import warnings
 from pathlib import Path
 
@@ -15,6 +13,10 @@ sys.path.insert(0, str(project_root))
 
 from cli.interface import main as cli_main
 from config import config
+from logging_config import get_logger
+
+
+logger = get_logger(__name__)
 
 
 def setup_logging(debug: bool = False) -> None:
@@ -74,7 +76,7 @@ def main() -> None:
         print("\\n👋 Goodbye!")
         sys.exit(0)
     except Exception as e:
-        logging.error(f"Fatal error: {str(e)}")
+        logger.error(f"Fatal error: {str(e)}")
         print(f"❌ Fatal error: {str(e)}")
         sys.exit(1)
 


### PR DESCRIPTION
## Summary
- initialize module-level logger via `get_logger` in main entrypoint
- use shared logger in execution sandbox

## Testing
- `python main.py` *(fails: DefaultCredentialsError: Your default credentials were not found)*
- `python - <<'PY'
from execution.sandbox import secure_executor
code = 'raise ValueError("boom")'
result = secure_executor.execute_code(code)
print('status:', result.status)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c1f8391fb083328d7a44706b9dfc0e