### PR TITLE
refactor: simplify analysis state

### DIFF
--- a/workflow/state.py
+++ b/workflow/state.py
@@ -23,16 +23,6 @@ class ExecutionStatus(Enum):
 
 
 @dataclass
-class QueryMetadata:
-    """Metadata about generated SQL queries."""
-    query_type: str
-    estimated_cost: Optional[float] = None
-    estimated_rows: Optional[int] = None
-    tables_used: List[str] = field(default_factory=list)
-    optimization_applied: bool = False
-
-
-@dataclass
 class GeneratedCode:
     """Information about generated Python code."""
     code_content: str
@@ -74,50 +64,35 @@ class ConversationMessage:
     message_type: str = "text"  # 'text', 'query', 'result', 'error'
 
 
-@dataclass
-class AnalysisLineage:
-    """Tracks the lineage of analysis operations."""
-    operation_id: str
-    parent_operation_id: Optional[str] = None
-    operation_type: str = ""
-    timestamp: datetime = field(default_factory=datetime.now)
-    inputs: Dict[str, Any] = field(default_factory=dict)
-    outputs: Dict[str, Any] = field(default_factory=dict)
-
-
 class AnalysisState(TypedDict, total=False):
     """Main state object for the LangGraph agent."""
     # Input Processing
     user_query: str
-    normalized_query: str
     process_type: ProcessType
     confidence_score: float
-    
+
     # Data Layer
     sql_query: str
-    query_metadata: QueryMetadata
     raw_dataset: Optional[pd.DataFrame]
     data_schema: Dict[str, Any]
-    
+
     # Code Generation
     generated_code: Optional[GeneratedCode]
     validation_results: Optional[ValidationResults]
     needs_python_analysis: bool
-    
+
     # Execution Results
     execution_results: Optional[ExecutionResults]
     analysis_outputs: Dict[str, Any]
     insights: str
-    
+
     # Error Handling
     error_context: Dict[str, Any]
-    retry_count: int
-    
+
     # Session Management
     session_id: str
     conversation_history: List[ConversationMessage]
-    analysis_lineage: List[AnalysisLineage]
-    
+
     # Control Flow
     next_step: str
     workflow_complete: bool
@@ -127,11 +102,9 @@ def create_initial_state(user_query: str, session_id: str) -> AnalysisState:
     """Create initial state for a new analysis request."""
     return AnalysisState(
         user_query=user_query,
-        normalized_query="",
         process_type=ProcessType.SQL,
         confidence_score=0.0,
         sql_query="",
-        query_metadata=QueryMetadata(query_type="unknown"),
         raw_dataset=None,
         data_schema={},
         generated_code=None,
@@ -141,10 +114,8 @@ def create_initial_state(user_query: str, session_id: str) -> AnalysisState:
         analysis_outputs={},
         insights="",
         error_context={},
-        retry_count=0,
         session_id=session_id,
         conversation_history=[],
-        analysis_lineage=[],
         next_step="understand_query",
         workflow_complete=False
     )


### PR DESCRIPTION
## Summary
- streamline AnalysisState by dropping unused query normalization, metadata, retry, and lineage fields
- remove unused QueryMetadata and AnalysisLineage dataclasses

## Testing
- `ruff check workflow/state.py`
- `pyright workflow/state.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c20395cee08332815dfbca081d3b89