### PR TITLE
feat: add contextual prompt for process classification

### DIFF
--- a/agents/schema_agent.py
+++ b/agents/schema_agent.py
@@ -1,5 +1,5 @@
 """AI agent for intelligent schema analysis and data understanding."""
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Union
 from dataclasses import dataclass
 import json
 
@@ -55,19 +55,31 @@ class SchemaIntelligenceAgent:
         self.llm_service = llm_client
         logger.info("SchemaIntelligenceAgent initialized")
     
-    def understand_data(self, query: str, schema_info: Dict[str, Any], 
-                       process_type: ProcessType) -> DataUnderstanding:
+    def understand_data(
+        self,
+        query_or_messages: Union[str, List[Dict[str, str]]],
+        schema_info: Dict[str, Any],
+        process_type: ProcessType,
+    ) -> DataUnderstanding:
         """
         Analyze the data schema in context of the user's query.
         
         Args:
-            query: User's natural language query
+            query_or_messages: User query or list of chat messages providing context
             schema_info: Available table schemas
             process_type: The determined process type (SQL, PYTHON, VISUALIZATION)
             
         Returns:
             DataUnderstanding with semantic analysis of relevant data
         """
+        if isinstance(query_or_messages, list):
+            query = "\n".join(
+                f"{m.get('role', 'user').capitalize()}: {m.get('content', '')}"
+                for m in query_or_messages
+            )
+        else:
+            query = query_or_messages
+
         with trace_agent_operation(
             name="analyze_data_schema",
             query=query,

--- a/agents/sql_agent.py
+++ b/agents/sql_agent.py
@@ -1,7 +1,7 @@
 """AI agent for intelligent SQL query generation."""
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Dict, Union
 
 from agents.process_classifier import ProcessTypeResult
 from agents.schema_agent import DataUnderstanding
@@ -49,19 +49,31 @@ class SQLGenerationAgent:
 
         logger.info("SQLGenerationAgent initialized")
     
-    def generate_sql(self, query: str, data_understanding: DataUnderstanding, 
-                    process_result: ProcessTypeResult) -> SQLGenerationResult:
+    def generate_sql(
+        self,
+        query_or_messages: Union[str, List[Dict[str, str]]],
+        data_understanding: DataUnderstanding,
+        process_result: ProcessTypeResult,
+    ) -> SQLGenerationResult:
         """
         Generate an optimized SQL query based on AI understanding of data and intent.
         
         Args:
-            query: Original user query
+            query_or_messages: Original user query or list of chat messages
             data_understanding: AI analysis of relevant data schema
             process_result: Process type classification result
             
         Returns:
             SQLGenerationResult with generated query and metadata
         """
+        if isinstance(query_or_messages, list):
+            query = "\n".join(
+                f"{m.get('role', 'user').capitalize()}: {m.get('content', '')}"
+                for m in query_or_messages
+            )
+        else:
+            query = query_or_messages
+
         with trace_agent_operation(
             name="generate_intelligent_sql",
             query=query,

--- a/workflow/nodes/sql_generation.py
+++ b/workflow/nodes/sql_generation.py
@@ -25,8 +25,9 @@ def generate_sql(state: AnalysisState) -> AnalysisState:
             suggested_tables=process_data["suggested_tables"],
         )
 
+        contextual_prompt = state.get("contextual_prompt", state["user_query"])
         data_understanding = schema_agent.understand_data(
-            state["user_query"],
+            contextual_prompt,
             state["data_schema"],
             state["process_type"],
         )
@@ -40,7 +41,7 @@ def generate_sql(state: AnalysisState) -> AnalysisState:
         }
 
         sql_result = sql_agent.generate_sql(
-            state["user_query"],
+            contextual_prompt,
             data_understanding,
             process_result,
         )


### PR DESCRIPTION
## Summary
- build contextual prompt using recent messages and user query
- allow process, schema, and sql agents to handle contextual prompts
- pipe combined prompt through query understanding and sql generation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'langgraph')*


------
https://chatgpt.com/codex/tasks/task_e_68c5666068b88332a4c7ba141997e498