### PR TITLE
feat: persist session artifacts

### DIFF
--- a/domain/entities/__init__.py
+++ b/domain/entities/__init__.py
@@ -69,3 +69,4 @@ class AnalysisSession:
     created_at: datetime
     conversation_history: List[ConversationMessage] = field(default_factory=list)
     analysis_count: int = 0
+    artifacts: Dict[str, Any] = field(default_factory=dict)

--- a/domain/services/session_store.py
+++ b/domain/services/session_store.py
@@ -9,12 +9,12 @@ class SessionStore(ABC):
 
     @abstractmethod
     def save_session(self, session: AnalysisSession) -> None:
-        """Persist a session instance."""
+        """Persist a session instance, including any cached artifacts."""
         raise NotImplementedError
 
     @abstractmethod
     def get_session(self, session_id: str) -> Optional[AnalysisSession]:
-        """Retrieve a session by its identifier."""
+        """Retrieve a session by its identifier with all artifacts."""
         raise NotImplementedError
 
     @abstractmethod

--- a/infrastructure/persistence/in_memory_session_store.py
+++ b/infrastructure/persistence/in_memory_session_store.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Optional
+import copy
 
 from domain.entities import AnalysisSession
 from domain.services import SessionStore
@@ -11,13 +12,16 @@ class InMemorySessionStore(SessionStore):
         self._sessions: Dict[str, AnalysisSession] = {}
 
     def save_session(self, session: AnalysisSession) -> None:
-        self._sessions[session.session_id] = session
+        # Store a deep copy to ensure artifacts are preserved without
+        # cross-request mutation.
+        self._sessions[session.session_id] = copy.deepcopy(session)
 
     def get_session(self, session_id: str) -> Optional[AnalysisSession]:
-        return self._sessions.get(session_id)
+        stored = self._sessions.get(session_id)
+        return copy.deepcopy(stored) if stored else None
 
     def list_sessions(self) -> List[AnalysisSession]:
-        return list(self._sessions.values())
+        return [copy.deepcopy(s) for s in self._sessions.values()]
 
     def delete_session(self, session_id: str) -> bool:
         return self._sessions.pop(session_id, None) is not None

--- a/workflow/state.py
+++ b/workflow/state.py
@@ -50,6 +50,7 @@ def create_initial_state(
     user_query: str,
     session_id: str,
     conversation_history: Optional[List[ConversationMessage]] = None,
+    artifacts: Optional[Dict[str, Any]] = None,
 ) -> AnalysisState:
     """Create initial state for a new analysis request."""
     return AnalysisState(
@@ -63,7 +64,7 @@ def create_initial_state(
         validation_results=None,
         needs_python_analysis=False,
         execution_results=None,
-        analysis_outputs={},
+        analysis_outputs=dict(artifacts) if artifacts else {},
         insights="",
         error_context={},
         session_id=session_id,


### PR DESCRIPTION
## Summary
- track per-session artifacts alongside conversation history
- ensure sessions stores copy and persist artifacts
- allow agent and state to accept existing artifacts for reuse

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c56b77101c8332831f5d84a608f632