### PR TITLE
Add pluggable artifact store with filesystem backend

### DIFF
--- a/domain/services/__init__.py
+++ b/domain/services/__init__.py
@@ -6,6 +6,7 @@ from .code_validator import CodeValidator
 from .code_executor import CodeExecutor
 from .insight_synthesizer import InsightSynthesizer
 from .session_store import SessionStore
+from .artifact_store import ArtifactStore
 
 __all__ = [
     "LLMClient",
@@ -14,4 +15,5 @@ __all__ = [
     "CodeExecutor",
     "InsightSynthesizer",
     "SessionStore",
+    "ArtifactStore",
 ]

--- a/domain/services/artifact_store.py
+++ b/domain/services/artifact_store.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+import pandas as pd
+
+
+class ArtifactStore(ABC):
+    """Interface for persisting analysis artifacts like DataFrames."""
+
+    @abstractmethod
+    def save_dataframe(self, df: pd.DataFrame, name: str) -> Dict[str, Any]:
+        """Persist a DataFrame and return metadata describing the stored artifact."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def load_dataframe(self, path: str) -> pd.DataFrame:
+        """Load a previously stored DataFrame from the given path."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def cleanup(self) -> None:
+        """Apply any retention or size policies to stored artifacts."""
+        raise NotImplementedError

--- a/infrastructure/persistence/__init__.py
+++ b/infrastructure/persistence/__init__.py
@@ -2,6 +2,7 @@
 from .base import DataRepository
 from .bigquery import BigQueryRepository
 from .in_memory_session_store import InMemorySessionStore
+from .filesystem_artifact_store import FilesystemArtifactStore
 
 # Default repository binding used across the application; injected at runtime
 data_repository: DataRepository | None = None
@@ -11,4 +12,5 @@ __all__ = [
     "data_repository",
     "BigQueryRepository",
     "InMemorySessionStore",
+    "FilesystemArtifactStore",
 ]

--- a/infrastructure/persistence/filesystem_artifact_store.py
+++ b/infrastructure/persistence/filesystem_artifact_store.py
@@ -1,0 +1,80 @@
+import os
+import time
+import uuid
+from typing import Dict, Any
+import pandas as pd
+
+from domain.services import ArtifactStore
+
+
+class FilesystemArtifactStore(ArtifactStore):
+    """Store artifacts on the local filesystem with basic cleanup policies."""
+
+    def __init__(
+        self,
+        base_path: str = "artifacts",
+        max_total_mb: float = 100.0,
+        max_age_seconds: int | None = None,
+    ) -> None:
+        self.base_path = base_path
+        self.max_total_mb = max_total_mb
+        self.max_age_seconds = max_age_seconds
+        os.makedirs(self.base_path, exist_ok=True)
+
+    def _artifact_path(self, name: str, fmt: str) -> str:
+        filename = f"{uuid.uuid4()}_{name}.{fmt}"
+        return os.path.join(self.base_path, filename)
+
+    def save_dataframe(self, df: pd.DataFrame, name: str) -> Dict[str, Any]:
+        fmt = "parquet"
+        path = self._artifact_path(name, fmt)
+        try:
+            df.to_parquet(path)
+        except Exception:
+            fmt = "csv"
+            path = self._artifact_path(name, fmt)
+            df.to_csv(path, index=False)
+        metadata = {
+            "type": "dataframe",
+            "path": path,
+            "format": fmt,
+            "rows": df.shape[0],
+            "columns": list(df.columns),
+        }
+        self.cleanup()
+        return metadata
+
+    def load_dataframe(self, path: str) -> pd.DataFrame:
+        if path.endswith(".parquet"):
+            return pd.read_parquet(path)
+        return pd.read_csv(path)
+
+    def cleanup(self) -> None:
+        files = []
+        total_size = 0
+        now = time.time()
+        for fname in os.listdir(self.base_path):
+            fpath = os.path.join(self.base_path, fname)
+            try:
+                stat = os.stat(fpath)
+            except FileNotFoundError:
+                continue
+            if self.max_age_seconds is not None and now - stat.st_mtime > self.max_age_seconds:
+                try:
+                    os.remove(fpath)
+                except FileNotFoundError:
+                    pass
+                continue
+            files.append((fpath, stat.st_mtime, stat.st_size))
+            total_size += stat.st_size
+        max_bytes = self.max_total_mb * 1024 * 1024
+        if total_size <= max_bytes:
+            return
+        files.sort(key=lambda x: x[1])  # oldest first
+        while total_size > max_bytes and files:
+            fpath, _, size = files.pop(0)
+            try:
+                os.remove(fpath)
+            except FileNotFoundError:
+                pass
+            total_size -= size

--- a/tests/test_artifact_store.py
+++ b/tests/test_artifact_store.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import time
+import pandas as pd
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from infrastructure.persistence import FilesystemArtifactStore
+
+
+def test_dataframe_serialization_and_loading(tmp_path):
+    store = FilesystemArtifactStore(base_path=str(tmp_path))
+    df = pd.DataFrame({"x": [1, 2]})
+    meta = store.save_dataframe(df, "df")
+    assert os.path.exists(meta["path"])
+    loaded = store.load_dataframe(meta["path"])
+    pd.testing.assert_frame_equal(loaded, df)
+
+
+def test_cleanup_removes_old_files(tmp_path):
+    store = FilesystemArtifactStore(base_path=str(tmp_path), max_total_mb=10, max_age_seconds=1)
+    df = pd.DataFrame({"x": [1, 2]})
+    meta = store.save_dataframe(df, "old")
+    # Make the file appear old
+    old_time = time.time() - 10
+    os.utime(meta["path"], (old_time, old_time))
+    store.cleanup()
+    assert not os.path.exists(meta["path"])

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -2,16 +2,19 @@ import os
 import sys
 from datetime import datetime
 from unittest.mock import MagicMock
+import pandas as pd
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from workflow.graph import SessionManager, DataAnalysisAgent
 from infrastructure.persistence.in_memory_session_store import InMemorySessionStore
+from infrastructure.persistence import FilesystemArtifactStore
 
 
-def create_manager():
+def create_manager(tmp_path=None):
     store = InMemorySessionStore()
     agent = MagicMock(spec=DataAnalysisAgent)
+    artifact_store = FilesystemArtifactStore(base_path=str(tmp_path)) if tmp_path else FilesystemArtifactStore()
 
     def fake_analysis(
         user_query: str,
@@ -32,12 +35,12 @@ def create_manager():
         }
 
     agent.analyze.side_effect = fake_analysis
-    manager = SessionManager(session_store=store, agent=agent)
-    return manager, store, agent
+    manager = SessionManager(session_store=store, agent=agent, artifact_store=artifact_store)
+    return manager, store, agent, artifact_store
 
 
-def test_start_session_initializes_metadata():
-    manager, store, _ = create_manager()
+def test_start_session_initializes_metadata(tmp_path):
+    manager, store, _, _ = create_manager(tmp_path)
     session_id = manager.start_session()
     session = store.get_session(session_id)
 
@@ -49,8 +52,8 @@ def test_start_session_initializes_metadata():
     assert session.artifacts == {}
 
 
-def test_analyze_query_updates_history_and_count():
-    manager, store, agent = create_manager()
+def test_analyze_query_updates_history_and_count(tmp_path):
+    manager, store, agent, _ = create_manager(tmp_path)
     session_id = manager.start_session()
 
     result = manager.analyze_query("hello", session_id)
@@ -62,26 +65,30 @@ def test_analyze_query_updates_history_and_count():
     assert result["conversation_history"][0]["content"] == "Echo: hello"
 
 
-def test_analyze_query_merges_artifacts():
-    manager, store, agent = create_manager()
+def test_analyze_query_merges_artifacts(tmp_path):
+    manager, store, agent, artifact_store = create_manager(tmp_path)
     session_id = manager.start_session()
+
+    df = pd.DataFrame({"a": [1, 2]})
 
     def analysis_with_artifacts(user_query: str, session_id: str, conversation_history=None, artifacts=None):
         return {
             "session_id": session_id,
             "conversation_history": [],
-            "analysis_outputs": {"df": "data"},
+            "analysis_outputs": {"df": df},
         }
 
     agent.analyze.side_effect = analysis_with_artifacts
     manager.analyze_query("hi", session_id)
 
     session = store.get_session(session_id)
-    assert session.artifacts == {"df": "data"}
+    meta = session.artifacts["df"]
+    loaded = artifact_store.load_dataframe(meta["path"])
+    pd.testing.assert_frame_equal(loaded, df)
 
 
-def test_get_session_history_returns_expected_structure():
-    manager, _, _ = create_manager()
+def test_get_session_history_returns_expected_structure(tmp_path):
+    manager, _, _, _ = create_manager(tmp_path)
     session_id = manager.start_session()
     manager.analyze_query("hello", session_id)
 
@@ -92,8 +99,8 @@ def test_get_session_history_returns_expected_structure():
     assert "created_at" in history
 
 
-def test_list_sessions_returns_expected_structure():
-    manager, _, _ = create_manager()
+def test_list_sessions_returns_expected_structure(tmp_path):
+    manager, _, _, _ = create_manager(tmp_path)
     session_id = manager.start_session()
     manager.analyze_query("hello", session_id)
 
@@ -104,8 +111,8 @@ def test_list_sessions_returns_expected_structure():
     assert "created_at" in sessions[0]
 
 
-def test_delete_session_removes_and_handles_unknown():
-    manager, store, _ = create_manager()
+def test_delete_session_removes_and_handles_unknown(tmp_path):
+    manager, store, _, _ = create_manager(tmp_path)
     session_id = manager.start_session()
 
     assert manager.delete_session(session_id) is True

--- a/workflow/graph.py
+++ b/workflow/graph.py
@@ -1,5 +1,6 @@
 """LangGraph workflow orchestration for the data analysis agent."""
 from typing import Dict, Any
+import pandas as pd
 from datetime import datetime
 import uuid
 
@@ -7,7 +8,7 @@ from langgraph.graph import StateGraph, END
 
 from workflow.state import AnalysisState, create_initial_state
 from domain.entities import ConversationMessage, AnalysisSession
-from domain.services import SessionStore
+from domain.services import SessionStore, ArtifactStore
 from workflow.nodes import (
     understand_query,
     generate_sql,
@@ -19,6 +20,7 @@ from workflow.nodes import (
     handle_error,
 )
 from infrastructure.persistence.in_memory_session_store import InMemorySessionStore
+from infrastructure.persistence import FilesystemArtifactStore
 from infrastructure.logging import get_logger
 
 logger = get_logger(__name__)
@@ -236,10 +238,12 @@ class SessionManager:
         self,
         session_store: SessionStore | None = None,
         agent: DataAnalysisAgent | None = None,
+        artifact_store: ArtifactStore | None = None,
     ) -> None:
         """Initialize session manager."""
         self.session_store = session_store or InMemorySessionStore()
         self.agent = agent or DataAnalysisAgent()
+        self.artifact_store = artifact_store or FilesystemArtifactStore()
 
     def start_session(self, session_id: str | None = None) -> str:
         """Start a new analysis session."""
@@ -283,8 +287,15 @@ class SessionManager:
                 )
             session.conversation_history = new_history
             session.analysis_count += 1
-            # Merge any new analysis outputs back into session artifacts
-            session.artifacts.update(results.get("analysis_outputs", {}))
+            processed = {}
+            for name, value in results.get("analysis_outputs", {}).items():
+                if isinstance(value, pd.DataFrame):
+                    processed[name] = self.artifact_store.save_dataframe(value, name)
+                else:
+                    processed[name] = value
+            session.artifacts.update(processed)
+            # Ensure cleanup policies are applied
+            self.artifact_store.cleanup()
             self.session_store.save_session(session)
 
         return results


### PR DESCRIPTION
## Summary
- add ArtifactStore interface and filesystem implementation for persistent artifacts
- serialize DataFrames to disk and track metadata paths in sessions
- enforce cleanup policies and add tests for serialization and retention

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57b6b24c4833297ed01874681f692